### PR TITLE
Prevent redundant LLM queries in success detection 

### DIFF
--- a/safari_sdk/agent/framework/tools/success_detection.py
+++ b/safari_sdk/agent/framework/tools/success_detection.py
@@ -248,6 +248,7 @@ class SubtaskSuccessDetectorV4(VisionSuccessDetectionTool):
     self._success_signal = False
     self._success_signal_images_time = None
     self._external_success_signal = None
+    self._last_queried_image_timestamp = None
     self._image_buffer.reset_start_images_map()
     self._image_buffer.reset_latest_images_map()
     await asyncio.sleep(0.5)  # wait for the image buffer to be ready.
@@ -312,6 +313,10 @@ class SubtaskSuccessDetectorV4(VisionSuccessDetectionTool):
     if not current_images_timestamp:
       logging.warning("[SD]: No images available.")
       return
+    if (self._last_queried_image_timestamp and 
+        current_images_timestamp <= self._last_queried_image_timestamp):
+      return
+    self._last_queried_image_timestamp = current_images_timestamp
     # Step 1: Build the prompt and query the model.
     query_success_signal_start_time = time.time()
     prompt = self._build_prompt(subtask=subtask)


### PR DESCRIPTION
Fixed Redundant Success Detection API Calls success_detection.py

Previously, the success detection loop checked for success every sd_async_sd_interval_s by spawning an asynchronous query task. If the LLM query took longer than the spawn interval and no new images arrived from the robot, subsequent loops would fire additional identical API calls against the exact same camera timestamps, burning tokens, risking rate limits, and wasting compute.
This PR added an internal tracker (self._last_queried_image_timestamp). The background task now verifies that current_images_timestamp is strictly newer than the last queried state before dispatching the request to the Gemini LLM.